### PR TITLE
Fix a wget option error

### DIFF
--- a/pkg/src/sbt/sbt
+++ b/pkg/src/sbt/sbt
@@ -33,7 +33,7 @@ if [ ! -f ${JAR} ]; then
   if hash curl 2>/dev/null; then
     curl --progress-bar -L ${URL1} > ${JAR} || curl --progress-bar -L ${URL2} > ${JAR}
   elif hash wget 2>/dev/null; then
-    wget --progress-bar -L ${URL1} -O ${JAR} || wget --progress-bar -L ${URL2} -O ${JAR}
+    wget --progress=bar -L ${URL1} -O ${JAR} || wget --progress=bar -L ${URL2} -O ${JAR}
   else
     printf "You do not have curl or wget installed, please install sbt manually from http://www.scala-sbt.org/\n"
     exit -1


### PR DESCRIPTION
It should be a mistake when it comes to wget command. 
wget command does not support progress-bar option, instead, it supports progress option. 
Before the change users will see:

```
wget: unrecognized option '--progress-bar'
Usage: wget [OPTION]... [URL]...
```

So I change it to "wget --progress=bar".
